### PR TITLE
fix typo

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,4 +1,4 @@
-name             '-whyrun_safe_execute'
+name             'whyrun_safe_execute'
 maintainer       'sonots'
 maintainer_email 'sonots@gmail.com'
 license          'All rights reserved'


### PR DESCRIPTION
Hello ! 

I found typo in metadata.rb.

``` ruby
# Berksfile
cookbook 'whyrun_safe_execute', git: "https://github.com/sonots/chef-resource-whyrun_safe_execute.git"
```

``` bash
$ berks vendor cookbooks
Fetching 'whyrun_safe_execute' from https://github.com/sonots/chef-resource-whyrun_safe_execute.git (at master)
In your Berksfile, you have:

  cookbook 'whyrun_safe_execute'

But that cookbook is actually named '-whyrun_safe_execute'

This can cause potentially unwanted side-effects in the future.

NOTE: If you do not explicitly set the 'name' attribute in the metadata, the name of the directory will be used instead. This is often a cause of confusion for dependency solving.
```

---

test

``` ruby
# Berksfile
cookbook 'whyrun_safe_execute', git: "https://github.com/kotatsu360/chef-resource-whyrun_safe_execute.git", branch:"fix-metadata-typo"
```

``` bash
$ berks vendor cookbooks
...
Using whyrun_safe_execute (0.1.0) from https://github.com/kotatsu360/chef-resource-whyrun_safe_execute.git (at fix-metadata-typo)
```

Thanks.
